### PR TITLE
Incorporate the Relay Agent Information obtained from the request into the respective reply

### DIFF
--- a/dhcp4/options.go
+++ b/dhcp4/options.go
@@ -55,6 +55,7 @@ const (
 	OptVendorIdentifier   Option = 60 // string
 	OptClientIdentifier   Option = 61 // string
 	OptFQDN               Option = 81 // string
+	OptAgentInformation   Option = 82 // struct
 
 	// You shouldn't need to use the following directly. Instead,
 	// refer to the fields in the Packet struct, and Marshal/Unmarshal

--- a/pixiecore/dhcp.go
+++ b/pixiecore/dhcp.go
@@ -183,6 +183,11 @@ func (s *Server) offerDHCP(pkt *dhcp4.Packet, mach Machine, serverIP net.IP, fwt
 		resp.Options[97] = pkt.Options[97]
 	}
 
+	// https://www.rfc-editor.org/rfc/rfc3046.html#section-2.2
+	if pkt.Options[dhcp4.OptAgentInformation] != nil {
+		resp.Options[dhcp4.OptAgentInformation] = pkt.Options[dhcp4.OptAgentInformation]
+	}
+
 	switch fwtype {
 	case FirmwareX86PC:
 		// This is completely standard PXE: we tell the PXE client to


### PR DESCRIPTION
[Server Operation of Relay Agent Information](https://www.rfc-editor.org/rfc/rfc3046.html#section-2.2)

Fix #19