### PR TITLE
feat: Add configurable server IP for DHCP responses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .git
 *.md
 LICENSE
+ipxe/ipxe/bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,6 @@ jobs:
         go-version: "1.23"
         cache: false
 
-    - name: make ipxe
-      run: |
-        make ipxe
-
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,11 @@ jobs:
         go-version: "1.23"
         cache: false
 
+    - name: fake ipxe/bin for linter
+      run: |
+        mkdir -p ipxe/ipxe/bin
+        touch ipxe/ipxe/bin/empty
+
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:

--- a/ipxe/ipxe.go
+++ b/ipxe/ipxe.go
@@ -8,7 +8,6 @@ import (
 
 // Files to embed get created during make ipxe
 //
-//nolint:typecheck
 //go:embed ipxe/bin
 var payload embed.FS
 

--- a/ipxe/ipxe.go
+++ b/ipxe/ipxe.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Files to embed get created during make ipxe
-// nolint:typecheck
 //
+//nolint:typecheck
 //go:embed ipxe/bin
 var payload embed.FS
 

--- a/pixiecore/dhcp.go
+++ b/pixiecore/dhcp.go
@@ -33,24 +33,24 @@ func (s *Server) serveDHCP(conn *dhcp4.Conn, fixedServerIP *net.IP) error {
 		}
 
 		if err = s.isBootDHCP(pkt); err != nil {
-			s.Log.Debug("Ignoring packet", "mac", pkt.HardwareAddr, "error", err)
+			s.Log.Debug("Ignoring packet", "mac", pkt.HardwareAddr.String(), "error", err)
 			continue
 		}
 		mach, fwtype, err := s.validateDHCP(pkt)
 		if err != nil {
-			s.Log.Info("Unusable packet", "mac", pkt.HardwareAddr, "error", err)
+			s.Log.Info("Unusable packet", "mac", pkt.HardwareAddr.String(), "error", err)
 			continue
 		}
 
-		s.Log.Debug("Got valid request to boot", "mac", mach.MAC, "guid", mach.GUID, "arch", mach.Arch)
+		s.Log.Debug("Got valid request to boot", "mac", mach.MAC.String(), "guid", mach.GUID, "arch", mach.Arch)
 
 		spec, err := s.Booter.BootSpec(mach)
 		if err != nil {
-			s.Log.Info("Couldn't get bootspec", "mac", pkt.HardwareAddr, "error", err)
+			s.Log.Info("Couldn't get bootspec", "mac", pkt.HardwareAddr.String(), "error", err)
 			continue
 		}
 		if spec == nil {
-			s.Log.Debug("No boot spec, ignoring boot request", "mac", pkt.HardwareAddr)
+			s.Log.Debug("No boot spec, ignoring boot request", "mac", pkt.HardwareAddr.String())
 			s.machineEvent(pkt.HardwareAddr, machineStateIgnored, "Machine should not netboot")
 			continue
 		}
@@ -69,19 +69,19 @@ func (s *Server) serveDHCP(conn *dhcp4.Conn, fixedServerIP *net.IP) error {
 		} else {
 			serverIP, err = interfaceIP(intf)
 			if err != nil {
-				s.Log.Info("Want to boot, but couldn't get a source address", "mac", pkt.HardwareAddr, "interface", intf.Name, "error", err)
+				s.Log.Info("Want to boot, but couldn't get a source address", "mac", pkt.HardwareAddr.String(), "interface", intf.Name, "error", err)
 				continue
 			}
 		}
 
 		resp, err := s.offerDHCP(pkt, mach, serverIP, fwtype)
 		if err != nil {
-			s.Log.Info("Failed to construct ProxyDHCP offer", "mac", pkt.HardwareAddr, "error", err)
+			s.Log.Info("Failed to construct ProxyDHCP offer", "mac", pkt.HardwareAddr.String(), "error", err)
 			continue
 		}
 
 		if err = conn.SendDHCP(resp, intf); err != nil {
-			s.Log.Info("Failed to send ProxyDHCP offer", "mac", pkt.HardwareAddr, "error", err)
+			s.Log.Info("Failed to send ProxyDHCP offer", "mac", pkt.HardwareAddr.String(), "error", err)
 			continue
 		}
 	}

--- a/pixiecore/pixiecore.go
+++ b/pixiecore/pixiecore.go
@@ -26,10 +26,11 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/metal-stack/pixie/api"
 	"github.com/metal-stack/pixie/dhcp4"
 	"github.com/metal-stack/v"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -174,6 +175,9 @@ type Server struct {
 	// HTTPPort.
 	HTTPStatusPort int
 
+	// Source IP of DHCP responses.
+	ServerIP *net.IP
+
 	// MetricsPort is the port of the metrics server.
 	MetricsPort int
 	// MetricsAddress is the bind address that the metrics server listens on.
@@ -264,8 +268,8 @@ func (s *Server) Serve() error {
 
 	s.Log.Debug("Starting Pixiecore goroutines", "version", v.V.String())
 
-	go func() { s.errs <- s.serveDHCP(dhcp) }()
-	go func() { s.errs <- s.servePXE(pxe) }()
+	go func() { s.errs <- s.serveDHCP(dhcp, s.ServerIP) }()
+	go func() { s.errs <- s.servePXE(pxe, s.ServerIP) }()
 	go func() { s.errs <- s.serveTFTP(tftpAddr) }()
 	go func() { s.errs <- serveHTTP(http, s.serveHTTP) }()
 	go func() { s.errs <- serveHTTP(metrics, s.serveMetrics) }()

--- a/pixiecore/pxe.go
+++ b/pixiecore/pxe.go
@@ -50,11 +50,11 @@ func (s *Server) servePXE(conn net.PacketConn, fixedServerIP *net.IP) error {
 		}
 
 		if err = s.isBootDHCP(pkt); err != nil {
-			s.Log.Debug("Ignoring packet", "mac", pkt.HardwareAddr, "addr", addr, "error", err)
+			s.Log.Debug("Ignoring packet", "mac", pkt.HardwareAddr.String(), "addr", addr, "error", err)
 		}
 		fwtype, err := s.validatePXE(pkt)
 		if err != nil {
-			s.Log.Info("Unusable packet", "mac", pkt.HardwareAddr, "addr", addr, "error", err)
+			s.Log.Info("Unusable packet", "mac", pkt.HardwareAddr.String(), "addr", addr, "error", err)
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (s *Server) servePXE(conn net.PacketConn, fixedServerIP *net.IP) error {
 		} else {
 			serverIP, err = interfaceIP(intf)
 			if err != nil {
-				s.Log.Info("Want to boot, but couldn't get a source address", "mac", pkt.HardwareAddr, "addr", addr, "interface", intf.Name, "error", err)
+				s.Log.Info("Want to boot, but couldn't get a source address", "mac", pkt.HardwareAddr.String(), "addr", addr, "interface", intf.Name, "error", err)
 				continue
 			}
 		}
@@ -81,7 +81,7 @@ func (s *Server) servePXE(conn net.PacketConn, fixedServerIP *net.IP) error {
 
 		bs, err := resp.Marshal()
 		if err != nil {
-			s.Log.Info("Failed to marshal PXE offer", "mac", pkt.HardwareAddr, "addr", addr, "error", err)
+			s.Log.Info("Failed to marshal PXE offer", "mac", pkt.HardwareAddr.String(), "addr", addr, "error", err)
 			continue
 		}
 


### PR DESCRIPTION
## Description

Add the ability to configure a fixed source IP address for DHCP and PXE responses through a new --server-ip flag. This is particularly useful when network interfaces don't have IPv4 addresses configured but DHCP/PXE services still need to operate with a specific source IP.

### Changes include:
- Add new ServerIP configuration option to Server struct
- Implement `--server-ip` CLI flag with IPv4 validation
- Modify DHCP and PXE services to use configured IP when available
- Maintain backward compatibility by keeping auto-detection as default
- Allow DHCP/PXE operation even when interfaces lack IPv4 addresses

### Example:
`pixiecore --server-ip 192.168.1.10 [other options]`

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
