### PR TITLE
fix: switch UEFI boot to snponly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ ipxe:
 	)
 	cp ipxe/branding.h ipxe/ipxe/src/config/local/branding.h
 	(cd ipxe/ipxe/src &&\
-		make bin/ipxe.pxe bin/undionly.kpxe bin-x86_64-efi/ipxe.efi bin-i386-efi/ipxe.efi EMBED=../../../pixiecore/boot.ipxe)
+		make bin/ipxe.pxe bin/undionly.kpxe bin-x86_64-efi/snponly.efi bin-i386-efi/snponly.efi EMBED=../../../pixiecore/boot.ipxe)
 	(rm -rf ipxe/ipxe/bin && mkdir ipxe/ipxe/bin)
 	mv -f ipxe/ipxe/src/bin/ipxe.pxe ipxe/ipxe/bin/ipxe.pxe
 	mv -f ipxe/ipxe/src/bin/undionly.kpxe ipxe/ipxe/bin/undionly.kpxe
-	mv -f ipxe/ipxe/src/bin-x86_64-efi/ipxe.efi ipxe/ipxe/bin/ipxe-x86_64.efi
-	mv -f ipxe/ipxe/src/bin-i386-efi/ipxe.efi ipxe/ipxe/bin/ipxe-i386.efi
+	mv -f ipxe/ipxe/src/bin-x86_64-efi/snponly.efi ipxe/ipxe/bin/snponly-x86_64.efi
+	mv -f ipxe/ipxe/src/bin-i386-efi/snponly.efi ipxe/ipxe/bin/snponly-i386.efi
 	(cd ipxe/ipxe/src && make veryclean)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,9 +22,9 @@ import (
 
 func main() {
 	cli.Ipxe[pixiecore.FirmwareX86PC] = ipxe.MustGet("undionly.kpxe")
-	cli.Ipxe[pixiecore.FirmwareEFI32] = ipxe.MustGet("ipxe-i386.efi")
-	cli.Ipxe[pixiecore.FirmwareEFI64] = ipxe.MustGet("ipxe-x86_64.efi")
-	cli.Ipxe[pixiecore.FirmwareEFIBC] = ipxe.MustGet("ipxe-x86_64.efi")
+	cli.Ipxe[pixiecore.FirmwareEFI32] = ipxe.MustGet("snponly-i386.efi")
+	cli.Ipxe[pixiecore.FirmwareEFI64] = ipxe.MustGet("snponly-x86_64.efi")
+	cli.Ipxe[pixiecore.FirmwareEFIBC] = ipxe.MustGet("snponly-x86_64.efi")
 	cli.Ipxe[pixiecore.FirmwareX86Ipxe] = ipxe.MustGet("ipxe.pxe")
 	cli.CLI()
 }


### PR DESCRIPTION
## Description

Use snponly.efi instead of full ipxe.efi, so iPXE stays aligned with the firmware-selected PXE interface and avoids getting stuck on the virtual device.

Closes #47
